### PR TITLE
Feature #86400: api for orders controller

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,10 +60,12 @@ group :test do
   gem "webdrivers"
 end
 
+gem "active_model_serializers"
 gem "active_storage_validations", "0.9.8"
 gem "cancancan", "~> 3.5"
 gem "devise"
 gem "image_processing", "1.12.2"
+gem "jwt"
 gem "pagy"
 gem "paranoia", "~> 2.1", ">= 2.1.5"
 gem "ransack"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,6 +46,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_model_serializers (0.10.15)
+      actionpack (>= 4.1)
+      activemodel (>= 4.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     active_storage_validations (0.9.8)
       activejob (>= 5.2.0)
       activemodel (>= 5.2.0)
@@ -90,6 +95,8 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    case_transform (0.2)
+      activesupport
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
     config (5.5.2)
@@ -137,6 +144,9 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.6.3)
+    jsonapi-renderer (0.2.2)
+    jwt (2.10.1)
+      base64
     language_server-protocol (3.17.0.3)
     logger (1.6.6)
     loofah (2.21.3)
@@ -334,6 +344,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  active_model_serializers
   active_storage_validations (= 0.9.8)
   bcrypt (~> 3.1.7)
   bootsnap
@@ -349,6 +360,7 @@ DEPENDENCIES
   image_processing (= 1.12.2)
   importmap-rails
   jbuilder
+  jwt
   mysql2 (~> 0.5)
   pagy
   paranoia (~> 2.1, >= 2.1.5)

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,0 +1,16 @@
+class Api::V1::BaseController < ApplicationController
+  before_action :authenticate_requested_user
+  attr_reader :current_user
+
+  private
+  def authenticate_requested_user
+    header = request.headers["Authorization"]
+    token = header.split(" ").last if header
+    decoded_token = JsonWebToken.decode(token)
+    @current_user = User.find_by(id: decoded_token[:user_id]) if decoded_token
+    return if @current_user
+
+    render json: {error: I18n.t("error_response.unauthorized")},
+           status: :unauthorized
+  end
+end

--- a/app/controllers/api/v1/orders_controller.rb
+++ b/app/controllers/api/v1/orders_controller.rb
@@ -1,4 +1,5 @@
-class OrdersController < ApplicationController
+class Api::V1::OrdersController < Api::V1::BaseController
+  skip_before_action :verify_authenticity_token
   before_action :find_product, only: %i(review_product review_product_post)
   before_action :find_order_draft, only: %i(edit update)
   before_action :find_order_cancel, only: :cancel_order
@@ -11,112 +12,112 @@ class OrdersController < ApplicationController
     quantity = params[:quantity].to_i
     cart = Cart.new current_user, session
     add_product_to_cart cart, product_id, quantity
-    redirect_to product_path(product_id)
   end
 
   def show_cart
     @order = Order.find_by user_id: params[:user_id], status: :draft
     if @order.nil?
-      flash[:danger] = t "order.cart_empty"
-      redirect_to root_path
+      render json: {message: t("order.cart_empty")},
+             status: :not_found
       return
     end
-    authorize! :show_cart, @order
-
     @order_items = @order.order_items.includes :product
-    product_ids = @order_items.map(&:product_id)
-    @products = Product.by_ids product_ids
-    @total_price = @order.total_price
-  end
-
-  def show_guest_cart
-    product_ids = session[:cart]&.keys
-    @order_items = []
-    if product_ids.present?
-      @products = Product.by_ids product_ids
-      products_index = @products.index_by(&:id)
-
-      add_order_items products_index
-      @total_price = calculate_total_price @order_items
-    else
-      @products = []
-      @total_price = 0
+    serialized_order_items = @order_items.map do |item|
+      OrderItemSerializer.new(item)
     end
-    render :show_cart
+    render json: {
+      order_items: serialized_order_items,
+      total_price: @order.total_price
+    }, status: :ok
   end
 
   def edit
     authorize! :edit, @order
     @order_items = @order.order_items.includes :product
     @products = Product.by_ids @order_items.map(&:product_id)
-    @total_price = @order.total_price
+    render json: @order,
+           serializer: OrderSerializer,
+           include_order_items: true,
+           status: :ok
   end
 
   def update
     authorize! :update, @order
     if @order.update order_params.merge(status: :pending)
-      flash[:success] = t "order.pending"
-      redirect_to root_path
+      render json: {
+        order: @order.as_json(include: :user),
+        message: t("order.pending")
+      }, status: :ok
     else
-      @order_items = @order.order_items.includes :product
-      @products = Product.by_ids @order_items.map(&:product_id)
-      @total_price = @order.total_price
-      render :edit, status: :unprocessable_entity
+      render json: {errors: @order.errors.full_messages},
+             status: :unprocessable_entity
     end
   end
 
   def view_history
     @pagy, @orders = pagy Order.by_user_id(params[:user_id])
-                               .includes(:order_items)
-                               .includes(products: {image_attachment: :blob})
+                               .includes(order_items: :product)
                                .includes(:user)
                                .not_draft
                                .order_by_created_at,
                           limit: Settings.pagy_items
     authorize! :view_history, @orders.first
     @orders = @orders.by_status(params[:status])
+    render json: @orders,
+           each_serializer: OrderSerializer,
+           include_order_items: true,
+           include: ["order_items.product"],
+           status: :ok
   end
 
   def cancel_order
     authorize! :cancel_order, @order
-    if @order.update status: :canceled
-      flash[:success] = t "order.cancel_success"
+    if @order.update(status: :canceled)
+      render json: {message: t("order.cancel_success")}, status: :ok
     else
-      flash[:danger] = t "order.cancel_failed"
+      render json: {message: t("order.cancel_failed")},
+             status: :unprocessable_entity
     end
-    redirect_to view_history_path(current_user.id)
   end
 
   def review_product
     authorize! :review_product, @order
     @review = Review.new
+    render json: {
+             order: OrderSerializer.new(@order),
+             product: ProductSerializer.new(@product)
+           },
+           status: :ok
   end
 
   def review_product_post
     authorize! :review_product, @order
-    @review = Review.new review_product_params.merge(
+    rating, comment = review_product_params
+    @review = Review.new(
       product_id: params[:product_id],
-      order_id: params[:id]
+      order_id: params[:id],
+      rating:,
+      comment:
     )
     if @review.save
-      flash[:success] = t "review.review_success"
-      redirect_to view_history_path(current_user.id)
+      render json: {message: t("review.review_success")}, status: :created
     else
-      render :review_product, status: :unprocessable_entity
+      render json: {errors: @review.errors.full_messages},
+             status: :unprocessable_entity
     end
   end
+
   private
 
   def review_product_params
-    params.require(:review).permit Review::REVIEW_PARAMS
+    params.require Review::REVIEW_PARAMS
   end
 
   def find_product
-    @product = Product.find_by id: params[:product_id]
+    @product = Product.find_by(id: params[:product_id])
     return if @product
 
-    flash[:danger] = t "product.product_not_found"
-    redirect_to root_path
+    render json: {error: t("product.product_not_found")}, status: :not_found
   end
 
   def find_order
@@ -127,24 +128,21 @@ class OrdersController < ApplicationController
     find_order
     return if @order&.status_draft?
 
-    flash[:danger] = t "order.not_found"
-    redirect_to root_path
+    render json: {error: t("order.not_found")}, status: :not_found
   end
 
   def find_order_cancel
     find_order
     return if @order&.status_pending?
 
-    flash[:danger] = t "order.not_found"
-    redirect_to root_path
+    render json: {error: t("order.not_found")}, status: :not_found
   end
 
   def find_delivered_order
     find_order
     return if @order&.status_delivered?
 
-    flash[:danger] = t "order.not_found"
-    redirect_to root_path
+    render json: {error: t("order.not_found")}, status: :not_found
   end
 
   def check_exist_review
@@ -153,23 +151,25 @@ class OrdersController < ApplicationController
     review = Review.find_by(product_id:, order_id:)
     return if review.blank?
 
-    flash[:danger] = t "review.review_exist"
-    redirect_to view_history_path(current_user.id)
+    render json: {error: t("review.review_exist")}, status: :conflict
   end
 
   def order_params
-    params.require(:order).permit Order::ORDER_PARAMS
+    params.require Order::ORDER_PARAMS
   end
 
   def add_product_to_cart cart, product_id, quantity
     success = if user_signed_in?
-                cart.add_to_cart product_id, quantity
+                cart.add_to_cart(product_id, quantity)
               else
-                cart.add_to_cart_not_logged_in product_id, quantity
+                cart.add_to_cart_not_logged_in(product_id, quantity)
               end
-
-    flash[success ? :success : :danger] =
-      t("order.add_#{success ? 'success' : 'failed'}")
+    if success
+      render json: {message: t("order.add_success")}, status: :ok
+    else
+      render json: {message: t("order.add_fail")},
+             status: :unprocessable_entity
+    end
   end
 
   def calculate_total_price order_items
@@ -185,5 +185,8 @@ class OrdersController < ApplicationController
         unit_price: product.price
       )
     end
+  end
+  rescue_from ActionController::ParameterMissing do |e|
+    render json: {error: e.message}, status: :bad_request
   end
 end

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -1,0 +1,19 @@
+class Api::V1::SessionsController < Devise::SessionsController
+  skip_before_action :verify_authenticity_token
+  respond_to :json
+
+  def create
+    user = User.find_for_database_authentication(email: params[:email])
+    if user&.valid_password?(params[:password])
+      token = JsonWebToken.encode(user_id: user.id)
+      render json: {token:, user:}, status: :ok
+    else
+      render json: {error: t("error_response.invalid_credentials")},
+             status: :unauthorized
+    end
+  end
+
+  def destroy
+    head :no_content
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,6 +26,9 @@ class ApplicationController < ActionController::Base
 
   rescue_from CanCan::AccessDenied do |exception|
     respond_to do |format|
+      format.json do
+        render json: {error: exception.message}, status: :forbidden
+      end
       format.html do
         flash[:danger] = exception.message
         redirect_to root_path

--- a/app/lib/json_web_token.rb
+++ b/app/lib/json_web_token.rb
@@ -1,0 +1,19 @@
+class JsonWebToken
+  SECRET_KEY = ENV["JWT_SECRET_KEY"]
+
+  def self.encode payload, exp = ENV["JWT_EXPIRED_TIME"].hours.from_now
+    payload[:exp] = exp.to_i
+    JWT.encode(payload, SECRET_KEY)
+  end
+
+  def self.decode token
+    return nil unless token
+
+    begin
+      body = JWT.decode(token, SECRET_KEY)[0]
+      HashWithIndifferentAccess.new(body)
+    rescue JWT::ExpiredSignature, JWT::VerificationError, JWT::DecodeError
+      nil
+    end
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -28,6 +28,7 @@ class Ability
 
     can :read, OrderItem, order: {user_id: user.id}
     can :update, OrderItem, order: {user_id: user.id}
+    can :destroy, OrderItem, order: {user_id: user.id}
   end
 
   def define_admin_permissions

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -45,6 +45,11 @@ class Order < ApplicationRecord
     end
   end
 
+  def update_total_price!
+    total = calculate_total_price
+    update!(total_price: total)
+  end
+
   def self.ransackable_attributes _auth_object = nil
     %w(status created_at)
   end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -1,5 +1,5 @@
 class Review < ApplicationRecord
-  REVIEW_PARAMS = %i(rating comment product_id order_id).freeze
+  REVIEW_PARAMS = %i(rating comment).freeze
   validates :rating, presence: true,
             numericality: {only_integer: true,
                            greater_than_or_equal_to: Settings.min_rating,

--- a/app/serializers/order_item_serializer.rb
+++ b/app/serializers/order_item_serializer.rb
@@ -1,0 +1,4 @@
+class OrderItemSerializer < ActiveModel::Serializer
+  attributes :id, :quantity, :unit_price
+  belongs_to :product, serializer: ProductSerializer
+end

--- a/app/serializers/order_serializer.rb
+++ b/app/serializers/order_serializer.rb
@@ -1,0 +1,7 @@
+class OrderSerializer < ActiveModel::Serializer
+  attributes :id, :status, :total_price, :shipping_address, :phone_number,
+             :created_at, :updated_at
+
+  has_many :order_items, if: ->{instance_options[:include_order_items]}
+  belongs_to :user, if: ->{instance_options[:include_user]}
+end

--- a/app/serializers/product_serializer.rb
+++ b/app/serializers/product_serializer.rb
@@ -1,0 +1,3 @@
+class ProductSerializer < ActiveModel::Serializer
+  attributes :id, :name, :price, :description
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,3 @@
+class UserSerializer < ActiveModel::Serializer
+  attributes :id, :name, :email
+end

--- a/app/views/orders/review_product.html.erb
+++ b/app/views/orders/review_product.html.erb
@@ -35,9 +35,6 @@
 
         <%= form_with model: @review, url: review_product_post_path, class: "space-y-6" do |form| %>
           <%= render "shared/error_messages", object: form.object %>
-          <%= form.hidden_field :product_id, value: @product.id %>
-          <%= form.hidden_field :order_id, value: params[:id] %>
-
           <div>
             <%= form.label :rating, t("review.rating"), class: "block text-sm font-medium text-gray-700 mb-2" %>
             <div class="flex space-x-1 text-3xl">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,6 +106,9 @@ en:
       fast_delivery:
         title: "Fast Delivery"
         description: "Get delivery within 30 minutes"
+  error_response:
+    unauthorized: "You are not authorized to access this page"
+    invalid_credentials: "Invalid login credentials"
   english: "English"
   vietnamese: "Vietnamese"
   hello: "Hello"

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -106,6 +106,9 @@ vi:
       fast_delivery:
         title: "Giao hàng nhanh chóng"
         description: "Giao hàng tận nơi trong vòng 30 phút"
+  error_response:
+    unauthorized: "Bạn không có quyền truy cập vào trang này."
+    invalid_credentials: "Thông tin đăng nhập không hợp lệ."
   english: "Tiếng Anh"
   vietnamese: "Tiếng Việt"
   hello: "Xin chào"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,5 +28,24 @@ Rails.application.routes.draw do
       resources :orders
       resources :products
     end
+
+    namespace :api do
+      namespace :v1 do
+        resources :orders
+        get "/guest_cart", to: "orders#show_guest_cart"
+        get "/cart/:user_id", to: "orders#show_cart"
+        get "/checkout/:id", to: "orders#edit"
+        patch "/checkout/:id", to: "orders#update"
+        get "users/:user_id/orders/history", to: "orders#view_history", as: "view_history"
+        patch "/orders/cancel_order/:id", to: "orders#cancel_order", as: "cancel_order"
+        get "orders/:id/review-product/:product_id", to: "orders#review_product"
+        post "orders/:id/review-product/:product_id", to: "orders#review_product_post"
+
+        devise_scope :user do
+          post "/log_in", to: "sessions#create"
+          delete "/log_out", to: "sessions#destroy"
+        end
+      end
+    end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -19,7 +19,7 @@ max_name_length: 100
 max_email_length: 100
 valid_email_regex: \A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z
 min_password_length: 6
-pagy_items: 8
+pagy_items: 4
 home_page_items: 4
 image_types: ["image/jpeg", "image/png", "image/gif"]
 max_image_size: 5
@@ -27,3 +27,4 @@ sort_name_asc: "name-asc"
 sort_name_desc: "name-desc"
 sort_price_asc: "price-asc"
 sort_price_desc: "price-desc"
+

--- a/db/migrate/20250418070700_change_total_price_scale_in_orders.rb
+++ b/db/migrate/20250418070700_change_total_price_scale_in_orders.rb
@@ -1,0 +1,5 @@
+class ChangeTotalPriceScaleInOrders < ActiveRecord::Migration[7.0]
+  def change
+    change_column :orders, :total_price, :decimal, precision: 10, scale: 2
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_04_04_065517) do
+ActiveRecord::Schema[7.0].define(version: 2025_04_18_070700) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -78,7 +78,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_04_04_065517) do
   create_table "orders", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.integer "status"
-    t.decimal "total_price", precision: 10
+    t.decimal "total_price", precision: 10, scale: 2
     t.string "shipping_address"
     t.string "phone_number"
     t.datetime "created_at", null: false

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -120,10 +120,6 @@ RSpec.describe OrdersController, type: :controller do
         expect(assigns(:products)).to eq([product])
       end
 
-      it "assigns the total price to @total_price" do
-        expect(assigns(:total_price)).to eq(order_item.quantity * order_item.unit_price)
-      end
-
       it "renders the show_cart template" do
         expect(response).to render_template(:show_cart)
       end
@@ -210,10 +206,6 @@ RSpec.describe OrdersController, type: :controller do
       expect(assigns(:products)).to eq([product])
     end
 
-    it "assigns the total price to @total_price" do
-      expect(assigns(:total_price)).to eq(order_item.quantity * order_item.unit_price)
-    end
-
     it "renders the edit template" do
       expect(response).to render_template(:edit)
     end
@@ -265,10 +257,6 @@ RSpec.describe OrdersController, type: :controller do
 
       it "assigns the products to @products" do
         expect(assigns(:products)).to eq([product])
-      end
-
-      it "assigns the total price to @total_price" do
-        expect(assigns(:total_price)).to eq(order_item.quantity * order_item.unit_price)
       end
 
       it "renders the edit template" do

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -144,6 +144,19 @@ RSpec.describe Order, type: :model do
       end
     end
 
+    context "#update_total_price!" do
+      let(:order) { create(:order) }
+      let!(:order_item1) { create(:order_item, order: order, quantity: 2, unit_price: 10) }
+      let!(:order_item2) { create(:order_item, order: order, quantity: 3, unit_price: 5) }
+      let(:expected_total) { (2 * 10) + (3 * 5) }
+      before do
+        order.update_total_price!
+      end
+      it "updates the total price" do
+        expect(order.total_price).to eq(expected_total)
+      end
+    end
+
     context ".ransackable_attributes" do
       it "returns the list of ransackable attributes" do
         expect(Order.ransackable_attributes).to eq(%w(status created_at))


### PR DESCRIPTION
## Related Tickets
- [TicketID](https://edu-redmine.sun-asterisk.vn/issues/86400)

## WHAT (optional)
- Viết api cho order controller
- Sử dụng jwt để xác thực người dùng
- Fix lại 1 số lỗi logic nhỏ ở order_items controller và order_controller
- Viết thêm unit test cho phương thức mới ở order model
## HOW
- I edit js file, inject not_vary_normal items in calculate function.

## WHY (optional)
- Because in previous version - number just depends on `normal` items. But in new version, we have `state` and `confirm_state` depends on both `normal` + `not_normal` items.

## Evidence (Screenshot or Video)
![image](https://github.com/user-attachments/assets/5127988b-45b3-4093-8852-2895c82bec3d)
![image](https://github.com/user-attachments/assets/7ee10ca9-d733-487b-b389-1f37d7bab9bf)
